### PR TITLE
Improve LWC compatibility

### DIFF
--- a/src/main/java/com/loohp/bookshelf/listeners/hooks/LWCEvents.java
+++ b/src/main/java/com/loohp/bookshelf/listeners/hooks/LWCEvents.java
@@ -24,23 +24,11 @@ import com.griefcraft.lwc.LWC;
 import com.griefcraft.model.Permission.Access;
 import com.griefcraft.model.Protection;
 import com.griefcraft.model.Protection.Type;
-import com.griefcraft.scripting.Module;
+import com.griefcraft.scripting.JavaModule;
 import com.griefcraft.scripting.event.LWCAccessEvent;
-import com.griefcraft.scripting.event.LWCBlockInteractEvent;
-import com.griefcraft.scripting.event.LWCCommandEvent;
-import com.griefcraft.scripting.event.LWCDropItemEvent;
-import com.griefcraft.scripting.event.LWCEntityInteractEvent;
-import com.griefcraft.scripting.event.LWCMagnetPullEvent;
-import com.griefcraft.scripting.event.LWCProtectionDestroyEvent;
-import com.griefcraft.scripting.event.LWCProtectionInteractEntityEvent;
 import com.griefcraft.scripting.event.LWCProtectionInteractEvent;
-import com.griefcraft.scripting.event.LWCProtectionRegisterEntityEvent;
 import com.griefcraft.scripting.event.LWCProtectionRegisterEvent;
-import com.griefcraft.scripting.event.LWCProtectionRegistrationPostEvent;
 import com.griefcraft.scripting.event.LWCProtectionRemovePostEvent;
-import com.griefcraft.scripting.event.LWCRedstoneEvent;
-import com.griefcraft.scripting.event.LWCReloadEvent;
-import com.griefcraft.scripting.event.LWCSendLocaleEvent;
 import com.loohp.bookshelf.Bookshelf;
 import com.loohp.bookshelf.api.events.PlayerOpenBookshelfEvent;
 import com.loohp.bookshelf.objectholders.BookshelfHolder;
@@ -48,20 +36,10 @@ import com.loohp.bookshelf.objectholders.LWCRequestOpenData;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 
-public class LWCEvents implements Module {
+public class LWCEvents extends JavaModule {
 
     public static void hookLWC() {
         LWC.getInstance().getModuleLoader().registerModule(Bookshelf.plugin, new LWCEvents());
-    }
-
-    @Override
-    public void onReload(LWCReloadEvent event) {
-        return;
-    }
-
-    @Override
-    public void load(LWC event) {
-        return;
     }
 
     @Override
@@ -94,46 +72,6 @@ public class LWCEvents implements Module {
     }
 
     @Override
-    public void onBlockInteract(LWCBlockInteractEvent event) {
-        return;
-    }
-
-    @Override
-    public void onCommand(LWCCommandEvent event) {
-        return;
-    }
-
-    @Override
-    public void onDestroyProtection(LWCProtectionDestroyEvent event) {
-        return;
-    }
-
-    @Override
-    public void onDropItem(LWCDropItemEvent event) {
-        return;
-    }
-
-    @Override
-    public void onEntityInteract(LWCEntityInteractEvent event) {
-        return;
-    }
-
-    @Override
-    public void onEntityInteractProtection(LWCProtectionInteractEntityEvent event) {
-        return;
-    }
-
-    @Override
-    public void onMagnetPull(LWCMagnetPullEvent event) {
-        return;
-    }
-
-    @Override
-    public void onPostRegistration(LWCProtectionRegistrationPostEvent event) {
-        return;
-    }
-
-    @Override
     public void onPostRemoval(LWCProtectionRemovePostEvent event) {
         Player player = event.getPlayer();
         if (player == null) {
@@ -157,16 +95,6 @@ public class LWCEvents implements Module {
     }
 
     @Override
-    public void onRedstone(LWCRedstoneEvent event) {
-        return;
-    }
-
-    @Override
-    public void onRegisterEntity(LWCProtectionRegisterEntityEvent event) {
-        return;
-    }
-
-    @Override
     public void onRegisterProtection(LWCProtectionRegisterEvent event) {
         Player player = event.getPlayer();
         if (player == null) {
@@ -174,11 +102,6 @@ public class LWCEvents implements Module {
         }
         Bookshelf.lwcCancelOpen.add(player.getUniqueId());
         Bukkit.getScheduler().runTaskLater(Bookshelf.plugin, () -> Bookshelf.lwcCancelOpen.remove(player.getUniqueId()), 5);
-    }
-
-    @Override
-    public void onSendLocale(LWCSendLocaleEvent event) {
-        return;
     }
 
 }


### PR DESCRIPTION
Some LWC implementations do not have all events (especially the Entity events),
this causes ClassNotFoundExceptions when using Bookshelf with those implementations.
Implementing JavaModule instead of Module avoids referencing those classes and so
fixes the issue.

Fixes https://github.com/Brokkonaut/LWCEntityLocking/issues/4#issuecomment-1146875936